### PR TITLE
Move jupiterone.md so support docs are auto-generated

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -2,14 +2,17 @@
 
 ## Veracode + JupiterOne Integration Benefits
 
-- Visualize Veracode scans, cwes, vulnerabilities, and findings in the JupiterOne graph.
-- Map Veracode findings to a code repo, project, or application in your JupiterOne account.
+- Visualize Veracode scans, cwes, vulnerabilities, and findings in the
+  JupiterOne graph.
+- Map Veracode findings to a code repo, project, or application in your
+  JupiterOne account.
 - Monitor Veracode cwes, findings, and vulnerabilities within the alerts app.
 - Monitor changes to Veracode scans using JupiterOne alerts.
 
 ## How it Works
 
-- JupiterOne periodically fetches Veracode scans, cwes, vulerabilities, and findings to update the graph.
+- JupiterOne periodically fetches Veracode scans, cwes, vulerabilities, and
+  findings to update the graph.
 - Write JupiterOne queries to review and monitor updates to the graph.
 - Configure alerts to reduce the noise of findings.
 - Configure alerts to take action when the JupiterOne graph changes.
@@ -32,15 +35,17 @@ instructions for obtaining these credentials][1].
 1. From the configuration **Gear Icon**, select **Integrations**.
 2. Scroll to the **Veracode** integration tile and click it.
 3. Click the **Add Configuration** button and configure the following settings:
+
 - Enter the **Account Name** by which you'd like to identify this Veracode
-   account in JupiterOne. Ingested entities will have this value stored in
-   `tag.AccountName` when **Tag with Account Name** is checked.
+  account in JupiterOne. Ingested entities will have this value stored in
+  `tag.AccountName` when **Tag with Account Name** is checked.
 - Enter a **Description** that will further assist your team when identifying
-   the integration instance.
+  the integration instance.
 - Select a **Polling Interval** that you feel is sufficient for your monitoring
-   needs. You may leave this as `DISABLED` and manually execute the integration.
+  needs. You may leave this as `DISABLED` and manually execute the integration.
 - Enter the **API ID** used to authenticate with Veracode.
 - Enter the **API Secret** used to authenticate with Veracode.
+
 4. Click **Create Configuration** once all values are provided.
 
 ## How to Uninstall

--- a/tools/docs.ts
+++ b/tools/docs.ts
@@ -3,7 +3,7 @@ import fs from "fs-extra";
 const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
 
 const packageNameSansOrg = pkg.name.split("/").pop();
-const baseDocsPath = `docs/jupiterone-io/${packageNameSansOrg}`;
+const baseDocsPath = `docs/jupiterone`;
 
 let docsExtension;
 if (fs.pathExistsSync(`${baseDocsPath}.md`)) {


### PR DESCRIPTION
The `docs` project is printing
```
Could not fetch documentation file for project graph-veracode
```
because this path name was wrong.