### PR TITLE
INT-824 add entity and relationship metadata to constants

### DIFF
--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -1,10 +1,20 @@
-import { StepEntityMetadata } from '@jupiterone/integration-sdk-core';
+import {
+  RelationshipClass,
+  RelationshipDirection,
+  StepEntityMetadata,
+  StepMappedRelationshipMetadata,
+  StepRelationshipMetadata,
+} from '@jupiterone/integration-sdk-core';
 
 export const Steps = {
   ACCOUNT: 'fetch-account',
+  FINDINGS: 'fetch-findings',
 };
 
-export const Entities: Record<'ACCOUNT', StepEntityMetadata> = {
+export const Entities: Record<
+  'ACCOUNT' | 'CWE' | 'SCAN' | 'VULNERABILITY' | 'FINDING',
+  StepEntityMetadata
+> = {
   ACCOUNT: {
     resourceName: 'Account',
     _type: 'veracode_account',
@@ -27,5 +37,151 @@ export const Entities: Record<'ACCOUNT', StepEntityMetadata> = {
       },
       required: [],
     },
+  },
+  // Note: CWEs entities are to be created via `createMappedRelationship` only. Set `skipTargetCreation` to false.
+  CWE: {
+    resourceName: 'CWE',
+    _type: 'cwe',
+    _class: ['Weakness'],
+    schema: {
+      additionalProperties: true,
+      properties: {
+        _key: { type: 'string' },
+        _type: { const: 'cwe' },
+        description: { type: 'string' },
+        displayName: { type: 'string' },
+        name: { type: 'string' },
+        recommendation: { type: 'string' },
+        references: { type: 'array', items: { type: 'string' } },
+        remediation_effort: { type: 'number' },
+        severity: { type: 'number' },
+      },
+      required: [],
+    },
+  },
+  SCAN: {
+    resourceName: 'Scan',
+    _type: 'veracode_scan',
+    _class: ['Service'],
+    schema: {
+      additionalProperties: true,
+      properties: {
+        _type: { const: 'veracode_scan' },
+        _key: { enum: ['veracode-scan-static', 'veracode-scan-dynamic'] },
+        category: { const: 'software' },
+        displayName: { enum: ['DYNAMIC', 'STATIC'] },
+        name: { enum: ['DYNAMIC', 'STATIC'] },
+        createdOn: { type: 'number' },
+        createdBy: { type: 'string' },
+        updatedOn: { type: 'number' },
+        updatedBy: { type: 'string' },
+      },
+      required: [],
+    },
+  },
+  VULNERABILITY: {
+    resourceName: 'Vulnerability',
+    _type: 'veracode_vulnerability',
+    _class: ['Vulnerability'],
+    schema: {
+      additionalProperties: true,
+      properties: {
+        _type: { const: 'veracode_vulnerability' },
+        _key: { type: 'string' },
+        id: { type: 'string' },
+        cwe: { type: 'string' },
+        name: { type: 'string' },
+        displayName: { type: 'string' },
+        description: { type: 'string' },
+        category: { type: 'string' },
+        scanType: { type: 'string' },
+        numericExploitability: { type: 'number' },
+        severity: { type: 'string' },
+        public: { type: 'boolean' },
+        createdOn: { type: 'number' },
+        createdBy: { type: 'string' },
+        updatedOn: { type: 'number' },
+        updatedBy: { type: 'string' },
+      },
+      required: [],
+    },
+  },
+  FINDING: {
+    resourceName: 'Finding',
+    _type: 'veracode_finding',
+    _class: ['Finding'],
+    schema: {
+      additionalProperties: true,
+      properties: {
+        _type: { const: 'veracode_finding' },
+        _key: { type: 'string' },
+        name: { type: 'string' },
+        displayName: { type: 'string' },
+        targets: { type: 'string' },
+        open: { type: 'boolean' },
+        reopened: { type: 'boolean' },
+        resolution: { type: 'string' },
+        resolutionStatus: { type: 'string' },
+        numericSeverity: { type: 'number' },
+        severity: { type: 'string' },
+        numericExploitability: { type: 'number' },
+        exploitability: { type: 'string' },
+        scanType: { type: 'string' },
+        foundDate: { type: 'number' },
+        modifiedDate: { type: 'number' },
+        sourceModule: { type: 'string' },
+        sourceFileName: { type: 'string' },
+        sourceFileLineNumber: { type: 'string' },
+        sourceFilePath: { type: 'string' },
+        createdOn: { type: 'number' },
+        createdBy: { type: 'string' },
+        updatedOn: { type: 'number' },
+        updatedBy: { type: 'string' },
+      },
+      required: [],
+    },
+  },
+};
+
+export const Relationships: Record<
+  | 'ACCOUNT_HAS_SCAN'
+  | 'SCAN_IDENTIFIED_VULNERABILITY'
+  | 'SCAN_IDENTIFIED_FINDING'
+  | 'VULNERABILITY_EXPLOITS_CWE'
+  | 'FINDING_IS_VULNERABILITY',
+  StepRelationshipMetadata | StepMappedRelationshipMetadata
+> = {
+  ACCOUNT_HAS_SCAN: {
+    // Note: SCAN ≡ SERVICE from naming perspective. Had to keep consistent with legacy graph project
+    _type: 'veracode_account_has_service',
+    sourceType: Entities.ACCOUNT._type,
+    _class: RelationshipClass.HAS,
+    targetType: Entities.SCAN._type,
+  },
+  SCAN_IDENTIFIED_VULNERABILITY: {
+    _type: 'veracode_scan_identified_vulnerability',
+    sourceType: Entities.SCAN._type,
+    _class: RelationshipClass.IDENTIFIED,
+    targetType: Entities.VULNERABILITY._type,
+  },
+  SCAN_IDENTIFIED_FINDING: {
+    _type: 'veracode_scan_identified_finding',
+    sourceType: Entities.SCAN._type,
+    _class: RelationshipClass.IDENTIFIED,
+    targetType: Entities.FINDING._type,
+  },
+  // mapped relationship
+  VULNERABILITY_EXPLOITS_CWE: {
+    _type: 'veracode_finding_exploits_cwe',
+    sourceType: Entities.VULNERABILITY._type,
+    _class: RelationshipClass.EXPLOITS,
+    targetType: Entities.CWE._type,
+    direction: RelationshipDirection.FORWARD,
+  },
+  FINDING_IS_VULNERABILITY: {
+    _type: 'veracode_finding_is_vulnerability',
+    sourceType: Entities.FINDING._type,
+    _class: RelationshipClass.IS,
+    targetType: Entities.VULNERABILITY._type,
   },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,25 +1,37 @@
-// Providers often supply types with their API libraries.
-
-export interface AcmeUser {
-  id: string;
+interface ApplicationProfile {
   name: string;
 }
 
-export interface AcmeGroup {
-  id: string;
-  name: string;
-  users?: Pick<AcmeUser, 'id'>[];
+export interface Application {
+  guid: string;
+  profile: ApplicationProfile;
+  last_completed_scan_date: String;
+  created: String;
+  Modified: String;
 }
 
-// Those can be useful to a degree, but often they're just full of optional
-// values. Understanding the response data may be more reliably accomplished by
-// reviewing the API response recordings produced by testing the wrapper client
-// (./client.ts). However, when there are no types provided, it is necessary to define
-// opaque types for each resource, to communicate the records that are expected
-// to come from an endpoint and are provided to iterating functions.
+interface LinkContents {
+  href: string;
+  templated?: boolean;
+}
 
-/*
-import { Opaque } from 'type-fest';
-export type AcmeUser = Opaque<any, 'AcmeUser'>;
-export type AcmeGroup = Opaque<any, 'AcmeGroup'>;
-*/
+interface Links {
+  self: LinkContents;
+  prev?: LinkContents;
+  first: LinkContents;
+  last: LinkContents;
+  next?: LinkContents;
+}
+
+interface PaginationData {
+  size: number;
+  total_elements: number;
+  total_pages: number;
+  number: number;
+}
+
+export interface ApplicationResponse {
+  _embedded: Application[];
+  _links: Links;
+  page: PaginationData;
+}


### PR DESCRIPTION
# Description
Adding entity and relationship metadata to constants. It is important that these are consistent with what is found in [original integration](https://github.com/JupiterOne/graph-veracode/blob/main/src/converters.ts). I looked to our graph data for integrations built using current sdk to verify defaults values for things like `relationship._key`, `relationship._toEntityKey` that are abstracted away from us. They line up with what was constructed in the old integration. That being said, an intrepid reviewer wishing to go on the same scavenger hunt to verify is a ⭐ .

Also added getApplications route, which will be used in the next and final large `fetch-findings` step.

Lastly, added some types around requests from Veracode Applications endpoint.

## Type of change

Please leave any irrelevant options unchecked.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [X] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [X] My changes properly paginate the target service provider's API
- [X] My changes properly handle rate limiting of the target service provider's
      API
- [X] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [X] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [X] I have updated the `CHANGELOG.md` file to describe my changes
- [X] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
