### PR TITLE
target graph-veracode current, bump major next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ and this project adheres to
 
 ## [Unreleased]
 
+- BREAKING: target `@jupiterone/graph-veracode` new major version to mark
+  deprecation of old project
+- add questions.yml
+
 [1.0.0] - 2022-03-16
+
+### NOTE
+
+- the following version was published under `@jupiterone/graph-veracode-v2`, all
+  new versions will be on `@jupiterone/graph-veracode`
 
 ### Fixed
 

--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -1,15 +1,37 @@
 ---
-sourceId: managed:template
+sourceId: managed:veracode
 integrationDefinitionId: '${integration_definition_id}'
 questions:
-  - id: integration-question-template-replace-me
-    title: What kinds of questions will this integration support?
+  - id: managed-question-veracode-open-finding-report
+    title:
+      What veracode applications have unmitigated findings with Very High
+      severity?
     description:
-      TODO Every integration should contribute questions! Please be carefule
-      to replace this before deploying the integration to JupiterOne.
+      Returns pertinent information about Veracode Applications, Findings, and
+      Weaknesses in which the Finding is "open" and has the highest severity
+      rating.
     queries:
       - name: good
         query: |
-          find * with _integrationDefinitionId = '${integration_definition_id}'
+          FIND veracode_application AS app 
+          THAT IDENTIFIED veracode_finding 
+            WITH numericSeverity = 5
+            AND open = true
+            AS finding
+          THAT EXPLOITS Weakness AS weakness
+          RETURN 
+            app.name,
+            app.lastCompletedScanDate, 
+            finding.name, 
+            finding.exploitability,
+            finding.description, 
+            finding.resolutionStatus, 
+            finding.fileName,
+            finding.fileLineNumber, 
+            weakness.name, 
+            weakness.references
     tags:
-      - template
+      - veracode
+      - threat
+      - compliance
+      - vuln-mgmt

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@jupiterone/graph-veracode-v2",
-  "version": "1.0.0",
+  "name": "@jupiterone/graph-veracode",
+  "version": "1.5.10",
   "description": "JupiterOne Veracode Integration",
   "license": "MPL-2.0",
   "main": "src/index.js",


### PR DESCRIPTION
will target `@jupiterone/graph-veracode` at `2.0.0` in subsequent PR.